### PR TITLE
Update submission parameter to return 1000 items

### DIFF
--- a/data/use-queue.js
+++ b/data/use-queue.js
@@ -3,7 +3,7 @@ import { useSWRInfinite } from "swr";
 import queueFetcher from "../libs/api-queue";
 
 const urlParameters =
-  "student_ids[]=all&include[]=assignment&workflow_state[]=submitted&workflow_state[]=pending_review&enrollment_state=active";
+  "student_ids[]=all&include[]=assignment&workflow_state[]=submitted&workflow_state[]=pending_review&enrollment_state=active&per_page=1000";
 let canvasUrl, apiKey, courses;
 
 const getKey = (pageIndex, previousPageData) => {


### PR DESCRIPTION
The default number of grading items returned is ten. 1000 is an arbitrarily high number to make sure
all items are returned.